### PR TITLE
Fixed compilation of invalid JS source

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,10 @@ ngAnnotatePlugin.prototype.apply = function apply(compiler) {
             function annotateFile(file) {
                 var map = compilation.assets[file].map(),
                     value = ngAnnotate(compilation.assets[file].source(), options);
-                compilation.assets[file] = new OriginalSource(value.src, file, map);
+
+                if (!value.errors) {
+                    compilation.assets[file] = new OriginalSource(value.src, file, map);
+                }
             }
 
             chunks.forEach(getFilesFromChunk);


### PR DESCRIPTION
The plugin breaks when used together with **extract-text-webpack-plugin**:

```
/Users/dremora/Code/my_project/node_modules/webpack/node_modules/webpack-core/lib/NormalModuleMixin.js:161
            if(isError) throw e;
                              ^
TypeError: Cannot call method 'split' of undefined
    at Function.SourceNode_fromStringWithSourceMap [as fromStringWithSourceMap] (/Users/dremora/Code/my_project/node_modules/webpack-core/node_modules/source-map/lib/source-map/source-node.js:62:43)
    at Source.OriginalSource (/Users/dremora/Code/my_project/node_modules/webpack-core/lib/OriginalSource.js:39:21)
    at annotateFile (/Users/dremora/Code/my_project/node_modules/ng-annotate-webpack-plugin/index.js:22:44)
    at Array.forEach (/Users/dremora/Code/my_project/node_modules/es6-loader/node_modules/es6-transpiler/node_modules/es5-shim/es5-shim.js:460:21)
    at Tapable.<anonymous> (/Users/dremora/Code/my_project/node_modules/ng-annotate-webpack-plugin/index.js:29:19)
    at Tapable.applyPluginsAsync (/Users/dremora/Code/my_project/node_modules/webpack/node_modules/tapable/lib/Tapable.js:73:13)
    at Tapable.<anonymous> (/Users/dremora/Code/my_project/node_modules/webpack/lib/Compilation.js:519:9)
    at Tapable.next (/Users/dremora/Code/my_project/node_modules/webpack/node_modules/tapable/lib/Tapable.js:69:11)
    at ExtractTextPlugin.<anonymous> (/Users/dremora/Code/my_project/node_modules/extract-text-webpack-plugin/index.js:171:4)
    at Tapable.applyPluginsAsync (/Users/dremora/Code/my_project/node_modules/webpack/node_modules/tapable/lib/Tapable.js:73:13)
```

After digging into the source, I've found out that the aforementioned plugin creates chunks with non-JS files (namely, raw CSS when used as shown in their example).

I'm not sure which plugin is to blame, but I found it easier to implement fix for this one.
