### PR TITLE
0.4.0: skip annotation of vendor chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,44 @@ var ngAnnotatePlugin = require('ng-annotate-webpack-plugin');
 module.exports = {
     /// ... rest of config
     plugins: [
+        new ngAnnotatePlugin()
+    ]
+}
+```
+To modify the default plugin options or to add options for `ng-annotate`:
+```javascript
+var webpack = require('webpack');
+var ngAnnotatePlugin = require('ng-annotate-webpack-plugin');
+
+module.exports = {
+    /// ... rest of config
+    plugins: [
         new ngAnnotatePlugin({
             add: true,
             // other ng-annotate options here
         })
     ]
 }
+```
 
+Since version 0.4.0: for performance reasons, chunks where the name starts with `vendors~` are not
+annotated. To customize this behavior, set the option `annotateChunk` to a method that returns
+`true` if a chunk should be annotated:
+
+```javascript
+var webpack = require('webpack');
+var ngAnnotatePlugin = require('ng-annotate-webpack-plugin');
+
+module.exports = {
+    /// ... rest of config
+    plugins: [
+        new ngAnnotatePlugin({
+            add: true,
+            annotateChunk: (chunk) => !chunk.name || !chunk.name.startsWith("vendors~"),
+            // other ng-annotate options here
+        })
+    ]
+}
 ```
 
 If you are looking for a loader instead of a plugin, use [ng-annotate-loader](https://github.com/huston007/ng-annotate-loader) instead

--- a/index.js
+++ b/index.js
@@ -9,12 +9,19 @@ function ngAnnotatePlugin(options) {
 ngAnnotatePlugin.prototype.apply = function apply(compiler) {
     var options = this.options;
 
+    // Skip vendor chunks by default unless options.annotateChunk is provided
+    var annotateChunk = options.annotateChunk || function(chunk) {
+        return !chunk.name || !chunk.name.startsWith("vendors~");
+    };
+
     compiler.hooks.compilation.tap('NgAnnotateWebpackPlugin', function(compilation) {
         compilation.hooks.optimizeChunkAssets.tapAsync('NgAnnotateWebpackPlugin', function(chunks, callback) {
             var files = [];
 
             function getFilesFromChunk(chunk) {
-                files = files.concat(chunk.files);
+                if (annotateChunk(chunk)) {
+                    files = files.concat(chunk.files);
+                }
             }
 
             function annotateFile(file) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-annotate-webpack-plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "webpack plugin that runs ng-annotate on your bundles",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Superseding https://github.com/jeffling/ng-annotate-webpack-plugin/pull/28.

Using `ng-annotate-webpack-plugin` can slow down builds a lot, especially in development mode. In a small playground project with AngularJS 1.7.8 and Angular 8, I get the following build times before and after the changes from this PR:

Production build (`webpack -p`, no sourcemaps, AOT): before 8.9 s, after: 6.2 s
Development build (`webpack-dev-server`, sourcemaps, JIT): **before: 64 s** (!) after: 6.9 s

It looks like `ng-annotate` is slowing down the development build by almost a factor of 10 when run on the vendor chunk.

This pull request disables annotation of vendor chunks and exposes an option to customize the behavior.
